### PR TITLE
feat: Add GitHub Skills activity (Closes #6)

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn version control, collaboration, and software development best practices with GitHub",
+        "schedule": "Wednesdays, 3:30 PM - 4:30 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
## Description
This pull request adds the missing GitHub Skills activity to the extracurricular activities list.

## Issue
Closes #6 - 🚨 Missing Activity: GitHub Skills

## Changes
- Added GitHub Skills activity to the activities dictionary
- Scheduled for Wednesdays, 3:30 PM - 4:30 PM
- Capacity: 25 participants
- Provides students with learning opportunities in version control and GitHub collaboration

## Testing
The new activity is now available in the API and should appear on the website activity list once this is merged.
